### PR TITLE
fix(docs): Traduz yml es-variableIncomes de pt-br para es

### DIFF
--- a/docs/es/openFinance/opusOpenFinance/integracaoDaPlataforma/compartilhamentoDeDados/anexos/yml/investimentos/es-variableIncomes.yml
+++ b/docs/es/openFinance/opusOpenFinance/integracaoDaPlataforma/compartilhamentoDeDados/anexos/yml/investimentos/es-variableIncomes.yml
@@ -2,45 +2,45 @@ openapi: 3.0.0
 info:
   title: API Variable Incomes - Integration Layer - OPUS Open Finance Brasil
   description: |
-    API de informações de operações de Renda Variável Open Finance Brasil – Fase 4. 
-    API que retorna informações de operações de investimento do tipo Renda Variável mantidas nas instituições transmissoras 
-    por seus clientes, incluindo dados como informações do produto, quantidade, saldos em posição do cliente, 
-    movimentações financeiras e detalhes da nota de negociação. Não possui segregação entre pessoa natural e pessoa jurídica. 
-    A granularidade de exposição de operações de renda variável se dá por cada ativo (ticker) da carteira do cliente. 
-    Compartilhamento considera lote padrão e fracionário, entretanto, no Open Finance Brasil, as informações são consolidadas via ticker do lote padrão. 
-    A defasagem em relação ao canal eletrônico da instituição deve ser o fechamento (pregão) do dia anterior (d-1). 
+    API de información de operaciones de Renta Variable Open Finance Brasil – Fase 4.
+    API que retorna información de operaciones de inversión del tipo Renta Variable mantenidas en las instituciones transmisoras
+    por sus clientes, incluyendo datos como información del producto, cantidad, saldos en posición del cliente,
+    movimientos financieros y detalles de la nota de negociación. No posee segregación entre persona natural y persona jurídica.
+    La granularidad de exposición de operaciones de renta variable se da por cada activo (ticker) de la cartera del cliente.
+    El compartir considera lote estándar y fraccionario, sin embargo, en Open Finance Brasil, las informaciones son consolidadas vía ticker del lote estándar.
+    El desfase en relación al canal electrónico de la institución debe ser el cierre (pregón) del día anterior (d-1).
 
-    Em relação ao aluguel de ações: neste momento não faz parte do escopo de compartilhamento a carteira/posição de aluguel do cliente (ativos alugados e movimentações relacionadas a esses ativos). 
-    Apenas deve ser compartilhado as transações de pagamento ou recebimento de juros oriundos dos contratos de ações alugadas (ou doadas) pelos clientes.
+    En relación al alquiler de acciones: en este momento no forma parte del alcance de compartir la cartera/posición de alquiler del cliente (activos alquilados y movimientos relacionados a esos activos).
+    Solo debe ser compartido las transacciones de pago o recepción de intereses provenientes de los contratos de acciones alquiladas (o donadas) por los clientes.
 
-    Em relação aos produtos FIAGRO e FII: quando negociados em balcão, estão fora do escopo do Open Finance.
+    En relación a los productos FIAGRO y FII: cuando son negociados en mostrador, están fuera del alcance del Open Finance.
 
-    Para o identificador do investimento (investmentId) deve ser adotado o seguinte comportamento:
+    Para el identificador de la inversión (investmentId) debe ser adoptado el siguiente comportamiento:
 
-    - Após 12 meses sem movimentações e com quantidade de ativos zerada, o resourceId correspondente ao investmentId em questão deve passar ao status UNAVAILABLE;
+    - Después de 12 meses sin movimientos y con cantidad de activos en cero, el resourceId correspondiente al investmentId en cuestión debe pasar al estatus UNAVAILABLE;
 
-    - Nas situações em que o cliente compre novamente o ativo após um período de 12 meses sem movimentação e com quantidade de ativos zerada, 
-    o mesmo identificador (investmentId) deve ser utilizado. Especificamente para tais produtos, o status do recurso na 
-    resources deve passar de UNAVAILABLE para AVAILABLE.
+    - En las situaciones en que el cliente compre nuevamente el activo después de un período de 12 meses sin movimiento y con cantidad de activos en cero,
+    el mismo identificador (investmentId) debe ser utilizado. Específicamente para tales productos, el estatus del recurso en
+    resources debe pasar de UNAVAILABLE a AVAILABLE.
 
-    Segue abaixo tabela com o escopo de produtos a ser considerado para compartilhamento:
-     ```
+    A continuación se presenta una tabla con el alcance de productos a ser considerado para compartir:
+       ```
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | CLASSE DE ATIVOS     | PRODUTO                       | SUBPRODUTO           | DENOMINAÇÃO                       |
+       | CLASE DE ACTIVOS     | PRODUCTO                      | SUBPRODUCTO          | DENOMINACIÓN                      |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Fundos de Investimentos       |     -                | FIAGRO Listado                    |
+       | Renta Variable       | Fondos de Inversión           |     -                | FIAGRO Listado                    |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Ações                         | Subscrição           | Bonus / Direito / Recibo          |
+       | Renta Variable       | Acciones                      | Suscripción          | Bono / Derecho / Recibo           |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Fundos de Investimentos       | Fundo imobiliario    | FII Listado                       |
+       | Renta Variable       | Fondos de Inversión           | Fondo inmobiliario   | FII Listado                       |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Ações                         | À vista              | ON / PN / UNIT                    |
+       | Renta Variable       | Acciones                      | Al contado           | ON / PN / UNIT                    |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Fundos de índices             | ETF                  | ETF de Renda Variável             |
+       | Renta Variable       | Fondos de índices             | ETF                  | ETF de Renta Variable             |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Fundos de índices             | ETF                  | ETF Internacional                 |
+       | Renta Variable       | Fondos de índices             | ETF                  | ETF Internacional                 |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
-       | Renda Variável       | Fundos de índices             | ETF Renda Fixa       | ETF Renda Fixa                    |
+       | Renta Variable       | Fondos de índices             | ETF Renta Fija       | ETF Renta Fija                    |
        |----------------------|-------------------------------|----------------------|-----------------------------------|
        ```
   version: 4.0.0-rc.1-base1.2.1
@@ -49,27 +49,27 @@ info:
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
 tags:
   - name: Product List
-    description: Obtém a lista de operações de Renda Variável mantidas pelo cliente na instituição transmissora.
+    description: Obtiene la lista de operaciones de Renta Variable mantenidas por el cliente en la institución transmisora.
   - name: Product Identification
-    description: Obtém os dados da operação de Renda Variável identificada por investmentId.
+    description: Obtiene los datos de la operación de Renta Variable identificada por investmentId.
   - name: Balances
-    description: Obtém a posição da operação de Renda Variável identificada por investmentId.
+    description: Obtiene la posición de la operación de Renta Variable identificada por investmentId.
   - name: Transactions
-    description: Obtém as movimentações históricas (últimos 12 meses) da operação de Renda Variável identificada por investmentId.
+    description: Obtiene los movimientos históricos (últimos 12 meses) de la operación de Renta Variable identificada por investmentId.
   - name: Transactions Current
-    description: 'Obtém as movimentações recentes da operação de Renda Variável identificada por investmentId. O período a ser considerado para apresentação de movimentações será de até 7 dias - 7 dias anteriores da consulta, incluindo o dia da consulta (D-6).'
+    description: 'Obtiene los movimientos recientes de la operación de Renta Variable identificada por investmentId. El período a ser considerado para presentación de movimientos será de hasta 7 días - 7 días anteriores de la consulta, incluyendo el día de la consulta (D-6).'
   - name: Broker Note Details
     description: |
-      Obtém as informações da nota de negociação identificado nas movimentações de compra e venda de ativos em bolsa.
-      O brokerNoteId é enviado nos movimentos de compra ou venda de ativos e deve ser passada como parâmetro de entrada no endpoint “Nota de Negociação”.Como conteúdo do campo brokerNoteId é esperado que a transmissora gere um identificar único, imutável, para cada número (natural) de nota de negociação.
+      Obtiene las informaciones de la nota de negociación identificada en los movimientos de compra y venta de activos en bolsa.
+      El brokerNoteId es enviado en los movimientos de compra o venta de activos y debe ser pasado como parámetro de entrada en el endpoint "Nota de Negociación". Como contenido del campo brokerNoteId se espera que la transmisora genere un identificador único, inmutable, para cada número (natural) de nota de negociación.
 paths:
   /discovery:
     post:
       tags:
         - Product List
-      summary: Obtém uma lista de recursos representando todos os investimentos do tipo Renda Variável realizados pelo cliente.
+      summary: Obtiene una lista de recursos representando todas las inversiones del tipo Renta Variable realizadas por el cliente.
       operationId: discoverVariableIncomes
-      description: Método para obter a lista de investimentos do tipo Renda Variável mantidos pelo cliente na instituição transmissora.
+      description: Método para obtener la lista de inversiones del tipo Renta Variable mantenidas por el cliente en la institución transmisora.
       requestBody:
         required: true
         content:
@@ -109,9 +109,9 @@ paths:
     post:
       tags:
         - Product List
-      summary: Obtém a lista de operações de Renda Variável mantidas pelo cliente na instituição transmissora e para as quais ele tenha fornecido consentimento.
+      summary: Obtiene la lista de operaciones de Renta Variable mantenidas por el cliente en la institución transmisora y para las cuales él haya otorgado consentimiento.
       operationId: variableIncomesGetInvestments
-      description: Obtém a lista de operações de Renda Variável mantidas pelo cliente na instituição transmissora e para as quais ele tenha fornecido consentimento.
+      description: Obtiene la lista de operaciones de Renta Variable mantenidas por el cliente en la institución transmisora y para las cuales él haya otorgado consentimiento.
       requestBody:
         required: true
         content:
@@ -151,9 +151,9 @@ paths:
     post:
       tags:
         - Product Identification
-      summary: Obtém os dados da operação de Renda Variável identificada por investmentId.
+      summary: Obtiene los datos de la operación de Renta Variable identificada por investmentId.
       operationId: variableIncomesGetInvestmentsInvestmentId
-      description: Obtém os dados da operação de Renda Variável identificada por investmentId.
+      description: Obtiene los datos de la operación de Renta Variable identificada por investmentId.
       requestBody:
         required: true
         content:
@@ -193,17 +193,17 @@ paths:
     post:
       tags:
         - Balances
-      summary: Obtém a posição da operação de Renda Variável identificada por investmentId.
+      summary: Obtiene la posición de la operación de Renta Variable identificada por investmentId.
       operationId: variableIncomesGetInvestmentsInvestmentIdBalances
       description: |
-        Obtém a posição da operação de Renda Variável identificada por investmentId.
+        Obtiene la posición de la operación de Renta Variable identificada por investmentId.
 
-        Nos casos em que não houver posição para o investimento, ou seja, quantidade de ativos e valores monetários zerados, mas o mesmo ainda estiver no prazo de exposição (até 12 meses após a última movimentação), deve se retornar status code 200 e para o payload de retorno considerar os valores abaixo. Campos não obrigatórios não devem ser retornados: 
+        En los casos en que no haya posición para la inversión, o sea, cantidad de activos y valores monetarios en cero, pero la misma aún esté en el plazo de exposición (hasta 12 meses después del último movimiento), se debe retornar status code 200 y para el payload de retorno considerar los valores abajo. Campos no obligatorios no deben ser retornados:
 
-        - Valores monetários: 0.00
-        - Quantidade de ativos: 0.00
-        - Data da última posição: mesmo conteúdo (data) do campo requestDateTime, com exceção da fração correspondente ao horário
-        - Fator de preço: 0.00
+        - Valores monetarios: 0.00
+        - Cantidad de activos: 0.00
+        - Fecha de la última posición: mismo contenido (fecha) del campo requestDateTime, con excepción de la fracción correspondiente al horario
+        - Factor de precio: 0.00
       requestBody:
         required: true
         content:
@@ -243,9 +243,9 @@ paths:
     post:
       tags:
         - Transactions
-      summary: Obtém as movimentações históricas (últimos 12 meses) da operação de Renda Variável identificada por investmentId.
+      summary: Obtiene los movimientos históricos (últimos 12 meses) de la operación de Renta Variable identificada por investmentId.
       operationId: variableIncomesGetInvestmentsInvestmentIdTransactions
-      description: Obtém as movimentações históricas (últimos 12 meses) da operação de Renda Variável identificada por investmentId.
+      description: Obtiene los movimientos históricos (últimos 12 meses) de la operación de Renta Variable identificada por investmentId.
       requestBody:
         required: true
         content:
@@ -285,9 +285,9 @@ paths:
     post:
       tags:
         - Transactions Current
-      summary: 'Obtém as movimentações recentes da operação de Renda Variável identificada por investmentId. O período a ser considerado para apresentação de movimentações será de até 7 dias - 7 dias anteriores da consulta, incluindo o dia da consulta (D-6).'
+      summary: 'Obtiene los movimientos recientes de la operación de Renta Variable identificada por investmentId. El período a ser considerado para presentación de movimientos será de hasta 7 días - 7 días anteriores de la consulta, incluyendo el día de la consulta (D-6).'
       operationId: variableIncomesGetInvestmentsInvestmentIdTransactionsCurrent
-      description: 'Obtém as movimentações recentes da operação de Renda Variável identificada por investmentId. O período a ser considerado para apresentação de movimentações será de até 7 dias - 7 dias anteriores da consulta, incluindo o dia da consulta (D-6).'
+      description: 'Obtiene los movimientos recientes de la operación de Renta Variable identificada por investmentId. El período a ser considerado para presentación de movimientos será de hasta 7 días - 7 días anteriores de la consulta, incluyendo el día de la consulta (D-6).'
       requestBody:
         required: true
         content:
@@ -328,12 +328,12 @@ paths:
       tags:
         - Broker Note Details
       summary: |
-        Obtém as informações da nota de negociação identificado nas movimentações de compra e venda de ativos em bolsa.
-        O brokerNoteId é enviado nos movimentos de compra ou venda de ativos e deve ser passada como parâmetro de entrada no endpoint “Nota de Negociação”.Como conteúdo do campo brokerNoteId é esperado que a transmissora gere um identificar único, imutável, para cada número (natural) de nota de negociação.
+        Obtiene las informaciones de la nota de negociación identificada en los movimientos de compra y venta de activos en bolsa.
+        El brokerNoteId es enviado en los movimientos de compra o venta de activos y debe ser pasado como parámetro de entrada en el endpoint "Nota de Negociación". Como contenido del campo brokerNoteId se espera que la transmisora genere un identificador único, inmutable, para cada número (natural) de nota de negociación.
       operationId: variableIncomesGetInvestmentsInvestmentIdBrokerNotesBrokerNoteId
       description: |
-        Obtém as informações da nota de negociação identificado nas movimentações de compra e venda de ativos em bolsa.
-        O brokerNoteId é enviado nos movimentos de compra ou venda de ativos e deve ser passada como parâmetro de entrada no endpoint “Nota de Negociação”.Como conteúdo do campo brokerNoteId é esperado que a transmissora gere um identificar único, imutável, para cada número (natural) de nota de negociação.
+        Obtiene las informaciones de la nota de negociación identificada en los movimientos de compra y venta de activos en bolsa.
+        El brokerNoteId es enviado en los movimientos de compra o venta de activos y debe ser pasado como parámetro de entrada en el endpoint "Nota de Negociación". Como contenido del campo brokerNoteId se espera que la transmisora genere un identificador único, inmutable, para cada número (natural) de nota de negociación.
       requestBody:
         required: true
         content:
@@ -441,7 +441,7 @@ components:
       additionalProperties: false
     ResponseVariableIncomesProductListData:
       type: object
-      description: Lista de ativos de renda variável mantidos pelo cliente na instituição transmissora e para as quais ele tenha fornecido consentimento.
+      description: Lista de activos de renta variable mantenidos por el cliente en la institución transmisora y para las cuales él haya otorgado consentimiento.
       required:
         - brandName
         - companyCnpj
@@ -449,13 +449,13 @@ components:
       properties:
         brandName:
           type: string
-          description: 'Nome da Marca reportada pelo participante no Open Finance. Recomenda-se utilizar, sempre que possível, o mesmo nome de marca atribuído no campo do diretório Customer Friendly Server Name (Authorisation Server).'
+          description: 'Nombre de la Marca reportada por el participante en Open Finance. Se recomienda utilizar, siempre que sea posible, el mismo nombre de marca atribuido en el campo del directorio Customer Friendly Server Name (Authorisation Server).'
           pattern: '[\w\W\s]*'
-          example: Organização A
+          example: Organización A
           maxLength: 80
         companyCnpj:
           type: string
-          description: 'Número completo do CNPJ da instituição responsável pelo Cadastro - o CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.'
+          description: 'Número completo del CNPJ de la institución responsable del Registro - el CNPJ corresponde al número de inscripción en el Registro de Persona Jurídica. Debe tener solo los números del CNPJ, sin máscara.'
           maxLength: 14
           pattern: '^\d{14}$'
           example: '21281590001660'
@@ -470,20 +470,20 @@ components:
       properties:
         issuerInstitutionCnpjNumber:
           type: string
-          description: CNPJ da instituição emissora. Caso a transmissora possua a informação o envio deste campo é obrigatório.
+          description: CNPJ de la institución emisora. Caso la transmisora posea la información el envío de este campo es obligatorio.
           maxLength: 14
           pattern: '^\d{14}$'
           example: '11225860000140'
         isinCode:
           type: string
           description: |
-            Código ISIN da emissão, Código ISIN do produto, Código da emissora: código universal que identifica cada valor mobiliário ou instrumento financeiro, conforme Norma ISO 6166.
+            Código ISIN de la emisión, Código ISIN del producto, Código de la emisora: código universal que identifica cada valor mobiliario o instrumento financiero, según Norma ISO 6166.
           maxLength: 12
           pattern: '^[A-Z]{2}([A-Z0-9]){9}\d{1}$'
           example: BRCST4CTF001
         ticker:
           type: string
-          description: Código de negociação para identificação de ativos negociados em bolsa.
+          description: Código de negociación para identificación de activos negociados en bolsa.
           maxLength: 35
           pattern: '[\w\W\s]*'
           example: PETR4
@@ -501,7 +501,7 @@ components:
         referenceDate:
           type: string
           format: date
-          description: Posição fechada para o ativo da data do dia anterior.
+          description: Posición cerrada para el activo de la fecha del día anterior.
           pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
           example: '2023-01-07'
           maxLength: 10
@@ -509,7 +509,7 @@ components:
           type: string
           format: double
           description: |
-            Fator que indica o número de ações utilizadas para a formação do preço. Valor informado deve ser maior que zero.
+            Factor que indica el número de acciones utilizadas para la formación del precio. Valor informado debe ser mayor que cero.
           pattern: '^\d{1,15}\.\d{2,8}$'
           maxLength: 24
           example: '100.0005'
@@ -520,7 +520,7 @@ components:
         quantity:
           type: string
           format: double
-          description: Quatidade total do ativo na data de referência.
+          description: Cantidad total del activo en la fecha de referencia.
           pattern: '^-?\d{1,15}\.\d{2,8}$'
           maxLength: 25
           example: '1000.00000004'
@@ -542,18 +542,18 @@ components:
         transactionTypeAdditionalInfo:
           type: string
           description: |
-            Informação adicional do tipo de movimentação, para preenchimento no caso de movimentações não delimitadas no domínio.
+            Información adicional del tipo de movimiento, para llenado en caso de movimientos no delimitados en el dominio.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com o valor 'OUTROS'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con el valor 'OUTROS'.
           maxLength: 100
           pattern: '[\w\W\s]*'
         transactionDate:
           type: string
           format: date
           description: |
-            Data da movimentação.
+            Fecha del movimiento.
 
-            [Restrição] Data do pregão: compartilhar movimentos até a data da posição.
+            [Restricción] Fecha del pregón: compartir movimientos hasta la fecha de la posición.
           maxLength: 10
           minLength: 10
           pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
@@ -562,16 +562,16 @@ components:
           type: string
           format: double
           description: |
-            Fator que indica o número de ações utilizadas para a formação do preço. Valor informado deve ser maior que zero.
+            Factor que indica el número de acciones utilizadas para la formación del precio. Valor informado debe ser mayor que cero.
           pattern: '^\d{1,15}\.\d{2,8}$'
           maxLength: 24
           example: '100.0005'
         transactionUnitPrice:
           type: object
           description: |
-            Preço unitário da movimentação: valor da unidade do produto na movimentação do investimento.
+            Precio unitario del movimiento: valor de la unidad del producto en el movimiento de la inversión.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com os valores 'COMPRA' ou 'VENDA'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con los valores 'COMPRA' o 'VENDA'.
           required:
             - amount
             - currency
@@ -579,13 +579,13 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               maxLength: 21
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               example: '1000.0004'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
@@ -593,15 +593,15 @@ components:
           type: string
           format: double
           description: |
-            Quantidade de ativos movimentados.
+            Cantidad de activos movilizados.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com os valores 'COMPRA' ou 'VENDA'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con los valores 'COMPRA' o 'VENDA'.
           maxLength: 24
           pattern: '^\d{1,15}\.\d{2,8}$'
           example: '42.00000025'
         transactionValue:
           type: object
-          description: Valor da operação realizada pelo cliente.
+          description: Valor de la operación realizada por el cliente.
           required:
             - amount
             - currency
@@ -609,13 +609,13 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               maxLength: 20
               pattern: '^\d{1,15}\.\d{2,4}$'
               example: '1000.04'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
@@ -640,18 +640,18 @@ components:
         transactionTypeAdditionalInfo:
           type: string
           description: |
-            Informação adicional do tipo de movimentação, para preenchimento no caso de movimentações não delimitadas no domínio.
+            Información adicional del tipo de movimiento, para llenado en caso de movimientos no delimitados en el dominio.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com o valor 'OUTROS'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con el valor 'OUTROS'.
           maxLength: 100
           pattern: '[\w\W\s]*'
         transactionDate:
           type: string
           format: date
           description: |
-            Data da movimentação.
+            Fecha del movimiento.
 
-            [Restrição] Data do pregão: compartilhar movimentos até a data da posição.
+            [Restricción] Fecha del pregón: compartir movimientos hasta la fecha de la posición.
           maxLength: 10
           minLength: 10
           pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
@@ -660,16 +660,16 @@ components:
           type: string
           format: double
           description: |
-            Fator que indica o número de ações utilizadas para a formação do preço. Valor informado deve ser maior que zero.
+            Factor que indica el número de acciones utilizadas para la formación del precio. Valor informado debe ser mayor que cero.
           pattern: '^\d{1,15}\.\d{2,8}$'
           maxLength: 24
           example: '100.0005'
         transactionUnitPrice:
           type: object
           description: |
-            Preço unitário da movimentação: valor da unidade do produto na movimentação do investimento.
+            Precio unitario del movimiento: valor de la unidad del producto en el movimiento de la inversión.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com os valores 'COMPRA' ou 'VENDA'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con los valores 'COMPRA' o 'VENDA'.
           required:
             - amount
             - currency
@@ -677,13 +677,13 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               maxLength: 21
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               example: '1000.0004'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
@@ -691,15 +691,15 @@ components:
           type: string
           format: double
           description: |
-            Quantidade de ativos movimentados.
+            Cantidad de activos movilizados.
 
-            [Restrição] Campo de preenchimento obrigatório pelas participantes quando o campo 'transactionType' for preenchido com os valores 'COMPRA' ou 'VENDA'.
+            [Restricción] Campo de llenado obligatorio por las participantes cuando el campo 'transactionType' sea llenado con los valores 'COMPRA' o 'VENDA'.
           maxLength: 24
           pattern: '^\d{1,15}\.\d{2,8}$'
           example: '42.00000025'
         transactionValue:
           type: object
-          description: Valor da operação realizada pelo cliente.
+          description: Valor de la operación realizada por el cliente.
           required:
             - amount
             - currency
@@ -707,13 +707,13 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               maxLength: 20
               pattern: '^\d{1,15}\.\d{2,4}$'
               example: '1000.04'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
@@ -724,7 +724,7 @@ components:
       additionalProperties: false
     VariableIncomesBalancesBlockedBalance:
       type: object
-      description: Valor não disponível para movimentação naquele momento por qualquer motivo (bloqueio judicial, bloqueio em garantia, entre outros). Prazo de carência não é considerado como bloqueio.
+      description: Valor no disponible para movilización en ese momento por cualquier motivo (bloqueo judicial, bloqueo en garantía, entre otros). Plazo de carencia no es considerado como bloqueo.
       required:
         - amount
         - currency
@@ -732,19 +732,19 @@ components:
         amount:
           type: string
           format: double
-          description: Valor relacionado ao objeto.
+          description: Valor relacionado al objeto.
           pattern: '^\d{1,15}\.\d{2,4}$'
           maxLength: 20
           example: '1000.04'
         currency:
           type: string
-          description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+          description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
           pattern: '^[A-Z]{3}$'
           maxLength: 3
           example: BRL
     VariableIncomesBalancesClosingPrice:
       type: object
-      description: Preço de fechamento da data de referência.
+      description: Precio de cierre de la fecha de referencia.
       required:
         - amount
         - currency
@@ -752,19 +752,19 @@ components:
         amount:
           type: string
           format: double
-          description: Valor relacionado ao objeto.
+          description: Valor relacionado al objeto.
           pattern: '^-?\d{1,15}\.\d{2,4}$'
           maxLength: 21
           example: '1000.0004'
         currency:
           type: string
-          description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+          description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
           pattern: '^[A-Z]{3}$'
           maxLength: 3
           example: BRL
     VariableIncomesBalancesGrossAmount:
       type: object
-      description: 'Valor do investimento anterior à dedução de impostos, taxas e tarifas (se houver), atualizado na data de referência. Quantidade de ativos dividido pelo Fator de cotação e multiplicado pelo pelo preço de fechamento da data de referência.'
+      description: 'Valor de la inversión anterior a la deducción de impuestos, tasas y tarifas (si las hay), actualizado en la fecha de referencia. Cantidad de activos dividido por el Factor de cotización y multiplicado por el precio de cierre de la fecha de referencia.'
       required:
         - amount
         - currency
@@ -772,19 +772,19 @@ components:
         amount:
           type: string
           format: double
-          description: Valor relacionado ao objeto.
+          description: Valor relacionado al objeto.
           pattern: '^-?\d{1,15}\.\d{2,4}$'
           maxLength: 21
           example: '1000.04'
         currency:
           type: string
-          description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+          description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
           pattern: '^[A-Z]{3}$'
           maxLength: 3
           example: BRL
     VariableIncomesMeta:
       type: object
-      description: Meta informações referente a API requisitada.
+      description: Meta información referente a la API requerida.
       required:
         - totalRecords
         - totalPages
@@ -793,15 +793,15 @@ components:
         totalRecords:
           type: integer
           format: int32
-          description: Número total de registros no resultado
+          description: Número total de registros en el resultado
           example: 1
         totalPages:
           type: integer
           format: int32
-          description: Número total de páginas no resultado
+          description: Número total de páginas en el resultado
           example: 1
         requestDateTime:
-          description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+          description: 'Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.'
           type: string
           maxLength: 20
           format: date-time
@@ -810,7 +810,7 @@ components:
     EnumVariableIncomesTransactionsType:
       type: string
       description: |
-        Tipo de movimentação na visão de investimento: entrada ou saída. Nos casos de pagamento de dividendos, JCP e aluguéis, fica convencionado que será considerado que o tipo de movimento será saída.
+        Tipo de movimiento en la visión de inversión: entrada o salida. En los casos de pago de dividendos, JCP y alquileres, queda convenido que será considerado que el tipo de movimiento será salida.
       enum:
         - ENTRADA
         - SAIDA
@@ -818,10 +818,10 @@ components:
     EnumVariableIncomesTransactionsTransactionType:
       type: string
       description: |
-        O campo deve classificar a movimentação em um dos tipos descritos: compra, venda, dividendos, JCP, aluguéis, transferência de custódia, transferência de titularidade e outros. 
-        O transmissor deve classificar as movimentações disponíveis associando-a a um dos itens do Enum listado neste campo. 
-        A opção OUTROS só deve ser utilizada para os casos em que de fato a movimentação compartilhada não possa ser classificada como um dos itens deste Enum. 
-        A expressão “aluguéis” deverá ser utilizada apenas para informar os juros/remuneração pagos/recebidos pelo cliente dos contratos de ações alugadas, seguindo o mesmo entendimento de ENTRADA/SAÍDA da expressão “dividendos”.
+        El campo debe clasificar el movimiento en uno de los tipos descritos: compra, venta, dividendos, JCP, alquileres, transferencia de custodia, transferencia de titularidad y otros.
+        El transmisor debe clasificar los movimientos disponibles asociándolos a uno de los ítems del Enum listado en este campo.
+        La opción OUTROS solo debe ser utilizada para los casos en que de hecho el movimiento compartido no pueda ser clasificado como uno de los ítems de este Enum.
+        La expresión "alquileres" deberá ser utilizada solo para informar los intereses/remuneración pagados/recibidos por el cliente de los contratos de acciones alquiladas, siguiendo el mismo entendimiento de ENTRADA/SALIDA de la expresión "dividendos".
       enum:
         - COMPRA
         - VENDA
@@ -835,7 +835,7 @@ components:
     EnumVariableIncomesTransactionsCurrentType:
       type: string
       description: |
-        Tipo de movimentação na visão de investimento: entrada ou saída. Nos casos de pagamento de dividendos, JCP e aluguéis, fica convencionado que será considerado que o tipo de movimento será saída.
+        Tipo de movimiento en la visión de inversión: entrada o salida. En los casos de pago de dividendos, JCP y alquileres, queda convenido que será considerado que el tipo de movimiento será salida.
       enum:
         - ENTRADA
         - SAIDA
@@ -843,10 +843,10 @@ components:
     EnumVariableIncomesTransactionsCurrentTransactionType:
       type: string
       description: |
-        O campo deve classificar a movimentação em um dos tipos descritos: compra, venda, dividendos, JCP, aluguéis, transferência de custódia, transferência de titularidade e outros. 
-        O transmissor deve classificar as movimentações disponíveis associando-a a um dos itens do Enum listado neste campo. 
-        A opção OUTROS só deve ser utilizada para os casos em que de fato a movimentação compartilhada não possa ser classificada como um dos itens deste Enum. 
-        A expressão “aluguéis” deverá ser utilizada apenas para informar os juros/remuneração pagos/recebidos pelo cliente dos contratos de ações alugadas, seguindo o mesmo entendimento de ENTRADA/SAÍDA da expressão “dividendos”.
+        El campo debe clasificar el movimiento en uno de los tipos descritos: compra, venta, dividendos, JCP, alquileres, transferencia de custodia, transferencia de titularidad y otros.
+        El transmisor debe clasificar los movimientos disponibles asociándolos a uno de los ítems del Enum listado en este campo.
+        La opción OUTROS solo debe ser utilizada para los casos en que de hecho el movimiento compartido no pueda ser clasificado como uno de los ítems de este Enum.
+        La expresión "alquileres" deberá ser utilizada solo para informar los intereses/remuneración pagados/recibidos por el cliente de los contratos de acciones alquiladas, siguiendo el mismo entendimiento de ENTRADA/SALIDA de la expresión "dividendos".
       enum:
         - COMPRA
         - VENDA
@@ -885,13 +885,13 @@ components:
       properties:
         brokerNoteNumber:
           type: string
-          description: Identificador da nota de negociação.
+          description: Identificador de la nota de negociación.
           maxLength: 16
           pattern: '^\d{1,16}$'
           example: '1854009930314350'
         grossValue:
           type: object
-          description: o valor da nota de negociação é o somatório das operações realizadas. Total de compra e venda do dia.
+          description: el valor de la nota de negociación es la sumatoria de las operaciones realizadas. Total de compra y venta del día.
           required:
             - amount
             - currency
@@ -899,21 +899,21 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '5000.0024'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         brokerageFee:
           type: object
           description: |
-            a taxa de corretagem incide sobre o valor bruto da nota de negociação, e é livremente pactuada entre o investidor e o seu intermediário. 
-            Pode ser cobrada como um valor fixo por operação, ou um como um percentual sobre o valor negociado, ou ainda de forma mista, conforme guia CVM do investidor.
+            la tasa de corretaje incide sobre el valor bruto de la nota de negociación, y es libremente pactada entre el inversor y su intermediario.
+            Puede ser cobrada como un valor fijo por operación, o como un porcentaje sobre el valor negociado, o aún de forma mixta, según guía CVM del inversor.
           required:
             - amount
             - currency
@@ -921,19 +921,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         clearingSettlementFee:
           type: object
-          description: Valor cobrado para liquidação na custódia.
+          description: Valor cobrado para liquidación en la custodia.
           required:
             - amount
             - currency
@@ -941,19 +941,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         clearingRegistrationFee:
           type: object
-          description: Valor cobrado para registro na custódia.
+          description: Valor cobrado para registro en la custodia.
           required:
             - amount
             - currency
@@ -961,19 +961,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         stockExchangeAssetTradeNoticeFee:
           type: object
-          description: Valor cobrada pela bolsa pelo aviso de negociação de ativo.
+          description: Valor cobrada por la bolsa por el aviso de negociación de activo.
           required:
             - amount
             - currency
@@ -981,19 +981,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         stockExchangeFee:
           type: object
-          description: Valor cobrado pela bolsa para remunerar os serviços de registro prestados.
+          description: Valor cobrado por la bolsa para remunerar los servicios de registro prestados.
           required:
             - amount
             - currency
@@ -1001,19 +1001,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         clearingCustodyFee:
           type: object
-          description: Taxa cobrada pelas IF para custódia.
+          description: Tasa cobrada por las IF para custodia.
           required:
             - amount
             - currency
@@ -1021,19 +1021,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         taxes:
           type: object
-          description: 'Impostos cobrados na operação, inclusive imposto de renda day-trade, exceto imposto de renda retido na fonte.'
+          description: 'Impuestos cobrados en la operación, inclusive impuesto a la renta day-trade, excepto impuesto a la renta retenido en la fuente.'
           required:
             - amount
             - currency
@@ -1041,19 +1041,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         incomeTax:
           type: object
-          description: Imposto de renda retido na fonte.
+          description: Impuesto a la renta retenido en la fuente.
           required:
             - amount
             - currency
@@ -1061,19 +1061,19 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '13.8751'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
         netValue:
           type: object
-          description: Valor líquido da nota de negociação após despesas com taxa de corretagem, taxa de liquidação, taxa de registro, taxa A.N.A, emolumentos, taxa de custódia, impostos e IRRF.
+          description: Valor líquido de la nota de negociación después de gastos con tasa de corretaje, tasa de liquidación, tasa de registro, tasa A.N.A, emolumentos, tasa de custodia, impuestos e IRRF.
           required:
             - amount
             - currency
@@ -1081,13 +1081,13 @@ components:
             amount:
               type: string
               format: double
-              description: Valor relacionado ao objeto.
+              description: Valor relacionado al objeto.
               pattern: '^-?\d{1,15}\.\d{2,4}$'
               maxLength: 21
               example: '4889.0012'
             currency:
               type: string
-              description: 'Moeda referente ao valor monetário, seguindo o modelo ISO-4217.'
+              description: 'Moneda referente al valor monetario, siguiendo el modelo ISO-4217.'
               pattern: '^[A-Z]{3}$'
               maxLength: 3
               example: BRL
@@ -1109,17 +1109,17 @@ components:
               - detail
             properties:
               code:
-                description: Código de erro específico do endpoint
+                description: Código de error específico del endpoint
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 255
               title:
-                description: Título legível por humanos deste erro específico
+                description: Título legible por humanos de este error específico
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 255
               detail:
-                description: Descrição legível por humanos deste erro específico
+                description: Descripción legible por humanos de este error específico
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 2048
@@ -1127,12 +1127,12 @@ components:
           $ref: '#/components/schemas/MetaOnlyRequestDateTime'
     MetaOnlyRequestDateTime:
       type: object
-      description: Meta informações referente à API requisitada.
+      description: Meta información referente a la API requerida.
       required:
         - requestDateTime
       properties:
         requestDateTime:
-          description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+          description: 'Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.'
           type: string
           maxLength: 20
           format: date-time
@@ -1154,17 +1154,17 @@ components:
               - detail
             properties:
               code:
-                description: Código de erro específico do endpoint
+                description: Código de error específico del endpoint
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 255
               title:
-                description: Título legível por humanos deste erro específico
+                description: Título legible por humanos de este error específico
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 255
               detail:
-                description: Descrição legível por humanos deste erro específico
+                description: Descripción legible por humanos de este error específico
                 type: string
                 pattern: '[\w\W\s]*'
                 maxLength: 2048
@@ -1172,7 +1172,7 @@ components:
           $ref: '#/components/schemas/MetaWithAbleAdditionalProperties'
     MetaWithAbleAdditionalProperties:
       type: object
-      description: Meta informações referente à API requisitada.
+      description: Meta información referente a la API requerida.
       required:
         - totalRecords
         - totalPages
@@ -1181,22 +1181,22 @@ components:
         totalRecords:
           type: integer
           format: int32
-          description: Número total de registros no resultado
+          description: Número total de registros en el resultado
           example: 1
         totalPages:
           type: integer
           format: int32
-          description: Número total de páginas no resultado
+          description: Número total de páginas en el resultado
           example: 1
         requestDateTime:
-          description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+          description: 'Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.'
           type: string
           maxLength: 20
           format: date-time
           example: '2021-05-21T08:30:00Z'
     LegacyId:
       description: |
-        Array de chave e valor com a chave de identificação do recurso no sistema de origem (legado), permitindo chaves compostas
+        Arreglo de clave y valor con la clave de identificación del recurso en el sistema de origen (legado), permitiendo claves compuestas
       type: array
       items:
         type: object
@@ -1206,12 +1206,12 @@ components:
         properties:
           key:
             description: |
-              Nome do campo do identificador no sistema de origem
+              Nombre del campo del identificador en el sistema de origen
             type: string
             example: internalResourceId
           value:
             description: |
-              Valor do campo do identificador no sistema de origem
+              Valor del campo del identificador en el sistema de origen
             type: string
             example: '1234'
         additionalProperties: false
@@ -1219,52 +1219,52 @@ components:
       maxItems: 10
     ToTransactionDate:
       description: |
-        Data final de filtragem.
-        [Restrição] Deve obrigatoriamente ser enviado caso o campo fromTransactionDate seja informado.
-        Caso não seja informado, deve ser assumido o dia atual.
+        Fecha final de filtrado.
+        [Restricción] Debe ser obligatoriamente enviado en caso de que el campo fromTransactionDate sea informado.
+        En caso de no ser informado, debe ser asumido el día actual.
       type: string
       maxLength: 10
       format: date
       example: '2021-05-21'
     FromTransactionDate:
       description: |
-        Data inicial de filtragem.
-        [Restrição] Deve obrigatoriamente ser enviado caso o campo toTransactionDate seja informado.
-        Caso não seja informado, deve ser assumido o dia atual.
+        Fecha inicial de filtrado.
+        [Restricción] Debe ser obligatoriamente enviado en caso de que el campo toTransactionDate sea informado.
+        En caso de no ser informado, debe ser asumido el día actual.
       type: string
       maxLength: 10
       format: date
       example: '2021-05-21'
     ToTransactionDateCurrent:
       description: |
-        Data final de filtragem.
-        O período máximo utilizado no filtro é de 7 dias inclusive (D-6).
-        [Restrição] Deve obrigatoriamente ser enviado caso o campo fromTransactionDate seja informado.
-        Caso não seja informado, deve ser assumido o dia atual.
+        Fecha final de filtrado.
+        El período máximo utilizado en el filtro es de 7 días inclusive (D-6).
+        [Restricción] Debe ser obligatoriamente enviado en caso de que el campo fromTransactionDate sea informado.
+        En caso de no ser informado, debe ser asumido el día actual.
       type: string
       maxLength: 10
       format: date
       example: '2023-02-01'
     FromTransactionDateCurrent:
       description: |
-        Data inicial de filtragem.
-        O período máximo utilizado no filtro é de 7 dias inclusive (D-6).
-        [Restrição] Deve obrigatoriamente ser enviado caso o campo toTransactionDate seja informado.
-        Caso não seja informado, deve ser assumido o dia atual.
+        Fecha inicial de filtrado.
+        El período máximo utilizado en el filtro es de 7 días inclusive (D-6).
+        [Restricción] Debe ser obligatoriamente enviado en caso de que el campo toTransactionDate sea informado.
+        En caso de no ser informado, debe ser asumido el día actual.
       type: string
       maxLength: 10
       format: date
       example: '2023-02-01'
     PaginationKey:
       description: |
-        Identificador de rechamada, utilizado para evitar a contagem de chamadas ao endpoint durante a paginação.
-        Esse campo pode ser repassado de um fluxo anterior como um valor residual e, embora possa estar presente na requisição, não é necessário utilizá-lo — ele pode simplesmente ser ignorado.
+        Identificador de rellamada, utilizado para evitar el conteo de llamadas al endpoint durante la paginación.
+        Este campo puede ser repasado de un flujo anterior como un valor residual y, aunque pueda estar presente en la solicitud, no es necesario utilizarlo — puede simplemente ser ignorado.
       type: string
       maxLength: 2048
       pattern: '[\w\W\s]*'
     Page:
       description: |
-        Número da página que está sendo requisitada (o valor da primeira página é 1).
+        Número de la página que está siendo solicitada (el valor de la primera página es 1).
       type: integer
       default: 1
       minimum: 1
@@ -1272,7 +1272,7 @@ components:
       format: int32
     PageSize:
       description: |
-        Quantidade total de registros por páginas.
+        Cantidad total de registros por página.
       type: integer
       default: 25
       minimum: 1
@@ -1280,7 +1280,7 @@ components:
       maximum: 1000
     ConsentDataSharing:
       description: |
-        Consentimento de compartilhamento de dados
+        Consentimiento de compartición de datos
       type: object
       required:
         - brandId
@@ -1293,8 +1293,8 @@ components:
         authExtraData:
           type: array
           description: |
-            Array de chave e valor com dados adicionais vindos do autorizador.
-            Esses dados podem ser utilizados como filtros de recursos.
+            Arreglo de clave y valor con datos adicionales provenientes del autorizador.
+            Estos datos pueden ser utilizados como filtros de recursos.
           items:
             type: object
             required:
@@ -1311,7 +1311,7 @@ components:
           deprecated: true
           type: array
           description: |
-            [Obsoleto] Array de chave e valor com os dados de identificação referente ao dono do consentimento.
+            [Obsoleto] Arreglo de clave y valor con los datos de identificación referentes al dueño del consentimiento.
           items:
             type: object
             required:
@@ -1327,14 +1327,14 @@ components:
         brandId:
           type: string
           description: |
-            Identificador da marca reportada pelo participante do Open Finance
+            Identificador de la marca reportada por el participante del Open Finance
           example: cbanco
           minLength: 1
           maxLength: 50
         creationDateTime:
           description: |
-            Data e hora em que o consentimento foi criado.
-            Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC (UTC time format).
+            Fecha y hora en que el consentimiento fue creado.
+            Una cadena con fecha y hora según especificación RFC-3339, siempre con la utilización de timezone UTC (UTC time format).
           type: string
           pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$ '
           example: '2021-05-21T08:30:00Z'
@@ -1342,7 +1342,7 @@ components:
         tpp:
           type: object
           description: |
-            Detalhes do TPP (Third Party Provider) que solicitou o consentimento
+            Detalles del TPP (Third Party Provider) que solicitó el consentimiento
           additionalProperties: false
           required:
             - name
@@ -1350,19 +1350,19 @@ components:
             name:
               type: string
               description: |
-                Nome do TPP que solicitou o consentimento
+                Nombre del TPP que solicitó el consentimiento
               example: GuiaBolsa
               maxLength: 100
         externalId:
           type: string
           description: |
-            Identificador do consentimento utilizado fora da plataforma Opus Open Finance
+            Identificador del consentimiento utilizado fuera de la plataforma Opus Open Finance
           example: urn:oob-bank:2f710909-4ccd-4998-8679-3d8de00e5ccf
           maxLength: 100
         loggedUser:
           type: object
           description: |
-            Usuário (pessoa natural) que encontra-se logado na instituição Transmissora de Dados.
+            Usuario (persona natural) que se encuentra logado en la institución Transmisora de Datos.
           additionalProperties: false
           required:
             - document
@@ -1370,7 +1370,7 @@ components:
             document:
               type: object
               description: |
-                Documento de identificação oficial do usuário.
+                Documento de identificación oficial del usuario.
               additionalProperties: false
               required:
                 - identification
@@ -1380,21 +1380,21 @@ components:
                   type: string
                   maxLength: 11
                   description: |
-                    Número do documento de identificação oficial do usuário.
+                    Número del documento de identificación oficial del usuario.
                   example: '11111111111'
                   pattern: ^\d{11}$
                 rel:
                   type: string
                   maxLength: 3
                   description: |
-                    Tipo do documento de identificação oficial do usuário.
+                    Tipo del documento de identificación oficial del usuario.
                   example: CPF
                   pattern: ^[A-Z]{3}$
         businessDocumentType:
           type: object
           description: |
-            Usuário (pessoa jurídica) que encontra-se logado na instituição Transmissora de Dados.
-            [Restrição] Preenchimento obrigatório se usuário logado na instituição Transmissora de Dados for um CNPJ (pessoa jurídica).
+            Usuario (persona jurídica) que se encuentra logado en la institución Transmisora de Datos.
+            [Restricción] Llenado obligatorio si el usuario logado en la institución Transmisora de Datos es un CNPJ (persona jurídica).
           additionalProperties: false
           required:
             - document
@@ -1402,7 +1402,7 @@ components:
             document:
               type: object
               description: |
-                Documento de identificação oficial do titular pessoa jurídica.
+                Documento de identificación oficial del titular persona jurídica.
               additionalProperties: false
               required:
                 - identification
@@ -1412,31 +1412,31 @@ components:
                   type: string
                   maxLength: 14
                   description: |
-                    Número do documento de identificação oficial do titular pessoa jurídica.
+                    Número del documento de identificación oficial del titular persona jurídica.
                   example: '11111111111111'
                   pattern: ^\d{14}$
                 rel:
                   type: string
                   maxLength: 4
                   description: |
-                    Tipo do documento de identificação oficial do titular pessoa jurídica.
+                    Tipo del documento de identificación oficial del titular persona jurídica.
                   example: CNPJ
                   pattern: ^[A-Z]{4}$
         resources:
           description: |
-            Lista de recursos permitidos pelo cliente
+            Lista de recursos permitidos por el cliente
           type: array
           items:
             type: object
             description: |
-              Recursos selecionados pelo cliente
+              Recursos seleccionados por el cliente
             required:
               - type
               - resourceLegacyId
             properties:
               type:
                 description: |
-                  Tipo do recurso
+                  Tipo del recurso
                 type: string
                 enum:
                   - ACCOUNT
@@ -1457,8 +1457,8 @@ components:
               authorizers:
                 deprecated: true
                 description: |
-                  [Obsoleto] Lista dos autorizadores para o recurso para casos de múltipla alçada.
-                  Caso o recurso seja selecionado, todos os autorizadores deverão aceitar o consentimento que o recurso faz parte
+                  [Obsoleto] Lista de los autorizadores para el recurso para casos de múltiple instancia.
+                  En caso de que el recurso sea seleccionado, todos los autorizadores deberán aceptar el consentimiento del que el recurso forma parte
                 type: array
                 items:
                   type: object
@@ -1468,7 +1468,7 @@ components:
                   properties:
                     cpf:
                       description: |
-                        CPF do autorizador
+                        CPF del autorizador
                       type: string
                       minLength: 11
                       maxLength: 11
@@ -1476,7 +1476,7 @@ components:
                       example: '11111111111'
                     name:
                       description: |
-                        Nome do autorizador
+                        Nombre del autorizador
                       type: string
                       example: Marco Antonio de Brito
                 minItems: 1
@@ -1488,9 +1488,9 @@ components:
           maxItems: 1000
         expirationDateTime:
           description: |
-            Data e hora de expiração da permissão.
-            De preenchimento obrigatório, reflete a data limite de validade do consentimento.
-            Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC (UTC time format).
+            Fecha y hora de expiración del permiso.
+            De llenado obligatorio, refleja la fecha límite de validez del consentimiento.
+            Una cadena con fecha y hora según especificación RFC-3339, siempre con la utilización de timezone UTC (UTC time format).
           type: string
           maxLength: 20
           pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$ '
@@ -1499,8 +1499,8 @@ components:
           type: array
           items:
             description: |
-              Somente para consentimentos de compartilhamento de dados.
-              Especifica os tipos de permissões de acesso às APIs no escopo do Open Finance Brasil - Fase 2, de acordo com os blocos de consentimento fornecidos pelo usuário e necessários ao acesso a cada endpoint das APIs.
+              Solamente para consentimientos de compartición de datos.
+              Especifica los tipos de permisos de acceso a las APIs en el alcance del Open Finance Brasil - Fase 2, de acuerdo con los bloques de consentimiento proporcionados por el usuario y necesarios para el acceso a cada endpoint de las APIs.
             type: string
             enum:
               - ACCOUNTS_READ
@@ -1549,7 +1549,7 @@ components:
     RequestMeta:
       type: object
       description: |
-        Objeto que contém dados referentes ao contexto no qual o request for recebido.
+        Objeto que contiene datos referentes al contexto en el cual la solicitud fue recibida.
       required:
         - correlationId
         - brandId
@@ -1557,14 +1557,14 @@ components:
         correlationId:
           type: string
           description: |
-            UUID que identifica o correlation ID da requisição realizada.
-            Deve ser propagado para todas as chamadas feitas entre sistemas e logado sempre que possível para facilitar o trace de erros
+            UUID que identifica el correlation ID de la solicitud realizada.
+            Debe ser propagado para todas las llamadas realizadas entre sistemas y registrado siempre que sea posible para facilitar el rastreo de errores
           pattern: ^(localID:)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
           example: localID:97623ed1-4732-4bf2-8d4b-ae7aced5443b
         brandId:
           type: string
           description: |
-            Identificador da marca reportada pelo participante do Open Finance
+            Identificador de la marca reportada por el participante del Open Finance
           example: cbanco
           minLength: 1
           maxLength: 50
@@ -1598,14 +1598,14 @@ components:
     MetaOnlyRequestDateTimeAndHasMoreRecords:
       type: object
       description: |
-        Meta informações referente à API requisitada.
+        Meta información referente a la API requerida.
       required:
         - requestDateTime
         - hasMoreRecords
       properties:
         requestDateTime:
           description: |
-            Data e hora da consulta, conforme especificação RFC-3339, formato UTC.
+            Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.
           type: string
           maxLength: 20
           format: date-time
@@ -1613,7 +1613,7 @@ components:
         hasMoreRecords:
           type: boolean
           description: |
-            Indica se tem mais registros a serem retornados (true) ou não (false).
+            Indica si hay más registros a ser retornados (true) o no (false).
           example: true
     NonSelectableResourceDiscoveryResponse:
       title: Non-Selectable Resource Discovery Response
@@ -1624,43 +1624,43 @@ components:
         data:
           type: object
           description: |
-            Objeto contendo a lista de recursos do cliente.
+            Objeto conteniendo la lista de recursos del cliente.
           required:
             - resources
           properties:
             resources:
               description: |
-                Lista de recursos relacionados ao discovery
+                Lista de recursos relacionados al discovery
               type: array
               items:
                 type: object
                 properties:
                   resourceLegacyId:
                     description: |
-                      Array de chave e valor com a chave de identificação do recurso no sistema de origem (legado), permitindo chaves compostas
+                      Arreglo de clave y valor con la clave de identificación del recurso en el sistema de origen (legado), permitiendo claves compuestas
                     type: array
                     items:
                       type: object
                       properties:
                         key:
                           description: |
-                            Nome do campo do identificador no sistema de origem
+                            Nombre del campo del identificador en el sistema de origen
                           type: string
                         value:
                           description: |
-                            Valor do campo do identificador no sistema de origem
+                            Valor del campo del identificador en el sistema de origen
                           type: string
                       required:
                         - key
                   validUntil:
                     description: |
-                      Indica a data até a qual o recurso estará disponível.
+                      Indica la fecha hasta la cual el recurso estará disponible.
                     type: string
                     format: date
                     example: '2025-05-21'
                   status:
                     description: |
-                      Indica o status atual do recurso
+                      Indica el estado actual del recurso
                     type: string
                     default: AVAILABLE
                     enum:
@@ -1670,22 +1670,22 @@ components:
                       - TEMPORARILY_UNAVAILABLE
                   authorizers:
                     description: |
-                      Lista dos autorizadores para o recurso para casos de multipla alçada.
-                      Caso o recurso seja selecionado, todos os autorizadores deverão aceitar o consentimento que o recurso faz parte
+                      Lista de los autorizadores para el recurso para casos de múltiple instancia.
+                      En caso de que el recurso sea seleccionado, todos los autorizadores deberán aceptar el consentimiento del que el recurso forma parte
                     type: array
                     items:
                       type: object
                       properties:
                         cpf:
                           description: |
-                            CPF do autorizador
+                            CPF del autorizador
                           type: string
                           minLength: 11
                           maxLength: 11
                           pattern: ^\d{11}$
                         name:
                           description: |
-                            Nome do autorizador
+                            Nombre del autorizador
                           type: string
                       required:
                         - cpf
@@ -1768,61 +1768,61 @@ components:
           $ref: '#/components/schemas/PaginationKey'
   responses:
     ResponseVariableIncomesBalances:
-      description: Dados obtidos com sucesso
+      description: Datos obtenidos con éxito
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesBalances'
     OKResponseVariableIncomesProductList:
-      description: Dados de fundos de investimentos obtidos com sucesso.
+      description: Datos de fondos de inversión obtenidos con éxito.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesProductList'
     OKResponseVariableIncomesProductIdentification:
-      description: Dados de fundos de investimentos obtidos com sucesso.
+      description: Datos de fondos de inversión obtenidos con éxito.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesProductIdentification'
     OKResponseVariableIncomesTransactions:
-      description: Dados de fundos de investimentos obtidos com sucesso.
+      description: Datos de fondos de inversión obtenidos con éxito.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesTransactions'
     OKResponseVariableIncomesTransactionsCurrent:
-      description: Dados de fundos de investimentos obtidos com sucesso.
+      description: Datos de fondos de inversión obtenidos con éxito.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesTransactionsCurrent'
     ResponseVariableIncomesBroker:
-      description: Dados de fundos de investimentos obtidos com sucesso.
+      description: Datos de fondos de inversión obtenidos con éxito.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseVariableIncomesBroker'
     BadRequest:
-      description: 'A requisição foi malformada, omitindo atributos obrigatórios, seja no payload ou através de atributos na URL.'
+      description: 'La solicitud fue malformada, omitiendo atributos obligatorios, sea en el payload o a través de atributos en la URL.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     Forbidden:
-      description: O token tem escopo incorreto ou uma política de segurança foi violada
+      description: El token tiene alcance incorrecto o una política de seguridad fue violada
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     GatewayTimeout:
-      description: GATEWAY TIMEOUT - A requisição não foi atendida dentro do tempo limite estabelecido
+      description: GATEWAY TIMEOUT - La solicitud no fue atendida dentro del tiempo límite establecido
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     InternalServerError:
-      description: Ocorreu um erro no gateway da API ou no microsserviço
+      description: Ocurrió un error en el gateway de la API o en el microservicio
       content:
         application/json; charset=utf-8:
           schema:
@@ -1848,100 +1848,100 @@ components:
                     - detail
                   properties:
                     code:
-                      description: Código de erro específico do endpoint
+                      description: Código de error específico del endpoint
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 255
                     title:
-                      description: Título legível por humanos deste erro específico
+                      description: Título legible por humanos de este error específico
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 255
                     detail:
-                      description: Descrição legível por humanos deste erro específico
+                      description: Descripción legible por humanos de este error específico
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 2048
               meta:
                 type: object
-                description: Meta informações referente à API requisitada.
+                description: Meta información referente a la API requerida.
                 required:
                   - requestDateTime
                 properties:
                   requestDateTime:
-                    description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+                    description: 'Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.'
                     type: string
                     maxLength: 20
                     format: date-time
                     example: '2021-05-21T08:30:00Z'
     MethodNotAllowed:
-      description: O consumidor tentou acessar o recurso com um método não suportado
+      description: El consumidor intentó acceder al recurso con un método no soportado
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     NotAcceptable:
-      description: A solicitação continha um cabeçalho Accept diferente dos tipos de mídia permitidos ou um conjunto de caracteres diferente de UTF-8
+      description: La solicitud contenía un encabezado Accept diferente de los tipos de medio permitidos o un conjunto de caracteres diferente de UTF-8
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     NotFound:
-      description: O recurso solicitado não existe ou não foi implementado
+      description: El recurso solicitado no existe o no fue implementado
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     TooManyRequests:
-      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite global de requisições concorrentes foi atingido'
+      description: 'La operación fue rechazada, pues muchas solicitudes fueron hechas dentro de un determinado período o el límite global de solicitudes concurrentes fue alcanzado'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     Unauthorized:
-      description: Cabeçalho de autenticação ausente/inválido ou token inválido
+      description: Cabecera de autenticación ausente/inválida o token inválido
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     UnprocessableEntity:
-      description: 'A sintaxe da requisição esta correta, mas não foi possível processar as instruções presentes.'
+      description: 'La sintaxis de la solicitud es correcta, pero no fue posible procesar las instrucciones presentes.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     Default:
-      description: Erro inesperado.
+      description: Error inesperado.
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     SiteIsOverloaded:
-      description: 'O site está sobrecarregado e a operação foi recusada, pois foi atingido o limite máximo de TPS global, neste momento.'
+      description: 'El sitio está sobrecargado y la operación fue rechazada, pues fue alcanzado el límite máximo de TPS global, en este momento.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorMetaSingle'
     BadRequestWithAdditionalProperties:
-      description: 'A requisição foi malformada, omitindo atributos obrigatórios, seja no payload ou através de atributos na URL.'
+      description: 'La solicitud fue malformada, omitiendo atributos obligatorios, sea en el payload o a través de atributos en la URL.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     ForbiddenWithAdditionalProperties:
-      description: O token tem escopo incorreto ou uma política de segurança foi violada
+      description: El token tiene alcance incorrecto o una política de seguridad fue violada
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     GatewayTimeoutWithAdditionalProperties:
-      description: GATEWAY TIMEOUT - A requisição não foi atendida dentro do tempo limite estabelecido
+      description: GATEWAY TIMEOUT - La solicitud no fue atendida dentro del tiempo límite establecido
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     InternalServerErrorWithAdditionalProperties:
-      description: Ocorreu um erro no gateway da API ou no microsserviço
+      description: Ocurrió un error en el gateway de la API o en el microservicio
       content:
         application/json; charset=utf-8:
           schema:
@@ -1967,23 +1967,23 @@ components:
                     - detail
                   properties:
                     code:
-                      description: Código de erro específico do endpoint
+                      description: Código de error específico del endpoint
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 255
                     title:
-                      description: Título legível por humanos deste erro específico
+                      description: Título legible por humanos de este error específico
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 255
                     detail:
-                      description: Descrição legível por humanos deste erro específico
+                      description: Descripción legible por humanos de este error específico
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 2048
               meta:
                 type: object
-                description: Meta informações referente à API requisitada.
+                description: Meta información referente a la API requerida.
                 required:
                   - totalRecords
                   - totalPages
@@ -1992,69 +1992,69 @@ components:
                   totalRecords:
                     type: integer
                     format: int32
-                    description: Número total de registros no resultado
+                    description: Número total de registros en el resultado
                     example: 1
                   totalPages:
                     type: integer
                     format: int32
-                    description: Número total de páginas no resultado
+                    description: Número total de páginas en el resultado
                     example: 1
                   requestDateTime:
-                    description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+                    description: 'Fecha y hora de la consulta, según especificación RFC-3339, formato UTC.'
                     type: string
                     maxLength: 20
                     format: date-time
                     example: '2021-05-21T08:30:00Z'
     MethodNotAllowedWithAdditionalProperties:
-      description: O consumidor tentou acessar o recurso com um método não suportado
+      description: El consumidor intentó acceder al recurso con un método no soportado
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     NotAcceptableWithAdditionalProperties:
-      description: A solicitação continha um cabeçalho Accept diferente dos tipos de mídia permitidos ou um conjunto de caracteres diferente de UTF-8
+      description: La solicitud contenía un encabezado Accept diferente de los tipos de medio permitidos o un conjunto de caracteres diferente de UTF-8
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     NotFoundWithAdditionalProperties:
-      description: O recurso solicitado não existe ou não foi implementado
+      description: El recurso solicitado no existe o no fue implementado
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     TooManyRequestsWithAdditionalProperties:
-      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite global de requisições concorrentes foi atingido'
+      description: 'La operación fue rechazada, pues muchas solicitudes fueron hechas dentro de un determinado período o el límite global de solicitudes concurrentes fue alcanzado'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     UnauthorizedWithAdditionalProperties:
-      description: Cabeçalho de autenticação ausente/inválido ou token inválido
+      description: Cabecera de autenticación ausente/inválida o token inválido
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     UnprocessableEntityWithAdditionalProperties:
-      description: 'A sintaxe da requisição esta correta, mas não foi possível processar as instruções presentes.'
+      description: 'La sintaxis de la solicitud es correcta, pero no fue posible procesar las instrucciones presentes.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     DefaultWithAdditionalProperties:
-      description: Erro inesperado.
+      description: Error inesperado.
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     SiteIsOverloadedWithAdditionalProperties:
-      description: 'O site está sobrecarregado e a operação foi recusada, pois foi atingido o limite máximo de TPS global, neste momento.'
+      description: 'El sitio está sobrecargado y la operación fue rechazada, pues fue alcanzado el límite máximo de TPS global, en este momento.'
       content:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseErrorWithAbleAdditionalProperties'
     OKResponseVariableIncomeDiscovery:
-      description: Lista de recursos representando os investimentos do tipo Renda Variável realizados pelo cliente obtidos com sucesso.
+      description: Lista de recursos representando las inversiones del tipo Renta Variable realizadas por el cliente obtenidas con éxito.
       content:
         application/json:
           schema:


### PR DESCRIPTION
O yml es-variableIncomes, dentro de Investimentos ->Compartilhamento de Dados na documentação em espanhol, estava em pt-br. Subo a tradução dele neste PR.